### PR TITLE
fix/未選択であった場合の表示の不具合修正

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,9 @@
+module PostsHelper
+    def display_enum(enum_value, enum_type)
+      if enum_value.present?
+        I18n.t("activerecord.enums.post.#{enum_type}.#{enum_value}", default: "未選択")
+      else
+        "未選択"
+      end
+    end
+  end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -21,18 +21,21 @@
         </div>
         <p class="mt-6 text-lg leading-relaxed"><%= simple_format(@post.content) %></p>
         <div class="grid grid-cols-2 gap-4 mt-6">
+
         <div class="stat">
         <div class="stat-title">所要時間</div>
-        <div class="stat-value text-xl"><%= t("activerecord.enums.post.required_time.#{@post.required_time}") %></div>
+        <div class="stat-value text-xl"><%= display_enum(@post.required_time, "required_time") %></div>
       </div>
       <div class="stat">
         <div class="stat-title">所要金額</div>
-        <div class="stat-value text-xl"><%= t("activerecord.enums.post.required_cost.#{@post.required_cost}") %></div>
+        <div class="stat-value text-xl"><%= display_enum(@post.required_cost, "required_cost") %></div>
       </div>
       <div class="stat">
         <div class="stat-title">効果のある部位</div>
-        <div class="stat-value text-xl"><%= t("activerecord.enums.post.parts.#{@post.parts}") %></div>
+        <div class="stat-value text-xl"><%= display_enum(@post.parts, "parts") %></div>
       </div>
+
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 概要
投稿詳細ページにて、所要金額、所要時間、部位が未選択であった時のレイアウトの不具合を修正しました。

### 行ったこと

- [x] display_enumヘルパーメソッドを追加して、nilだった場合に未選択と表示させるように修正
- [x] posts/show.html.erbにてdisplay_enumヘルパーメソッドを使用するよう修正

### 関連issue

https://github.com/tanakaami57b/bihaichinichinishitenarazu/issues/11