### PR TITLE
fix/ブックマーク解除後、ブックマーク一覧に遷移するように修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,16 +4,16 @@ class BookmarksController < ApplicationController
     def create
       post = Post.find(params[:post_id])
       current_user.bookmark(post)
-      redirect_to posts_path, notice: "これやる！リストに追加しました！"
+      redirect_to bookmarks_path, notice: "これやる！リストに追加しました！"
     end
 
     def destroy
-        bookmark = current_user.bookmarks.find_by(id: params[:id])
-        if bookmark
-          bookmark.destroy
-          redirect_to posts_path, notice: "これやる！リストを解除しました！", status: :see_other
-        else
-          redirect_to posts_path, alert: "ブックマークが見つかりませんでした。", status: :unprocessable_entity
-        end
+      bookmark = current_user.bookmarks.find_by(id: params[:id])
+      if bookmark
+        bookmark.destroy
+        redirect_to bookmarks_path, notice: "これやる！リストを解除しました！", status: :see_other
+      else
+        redirect_to bookmarks_path, alert: "ブックマークが見つかりませんでした。", status: :unprocessable_entity
       end
+    end
   end


### PR DESCRIPTION
### 概要
ブックマーク解除後、投稿一覧に遷移していたのをブックマーク一覧に遷移するよう修正しました。

### 行ったこと

- [x] BookmarksControllerのdestroyのリダイレクト先をbookmarks_pathに修正

### 関連issue
https://github.com/tanakaami57b/bihaichinichinishitenarazu/issues/14